### PR TITLE
removed WARNING, using WARN everywhere instead

### DIFF
--- a/gridappsd/loghandler.py
+++ b/gridappsd/loghandler.py
@@ -1,5 +1,5 @@
 import json
-from logging import CRITICAL, FATAL, ERROR, WARNING, WARN, INFO, DEBUG, NOTSET
+from logging import CRITICAL, FATAL, ERROR, WARN, INFO, DEBUG, NOTSET
 import os
 
 from . import topics as t
@@ -53,7 +53,7 @@ class Logger:
         self.log(message, ERROR)
 
     def warning(self, message):
-        self.log(message, WARNING)
+        self.log(message, WARN)
 
     def fatal(self, message):
         self.log(message, FATAL)

--- a/gridappsd/loghandler.py
+++ b/gridappsd/loghandler.py
@@ -9,8 +9,7 @@ _nameToLevel = {
     'CRITICAL': CRITICAL,
     'FATAL': FATAL,
     'ERROR': ERROR,
-    'WARN': WARNING,
-    'WARNING': WARNING,
+    'WARN': WARN,
     'INFO': INFO,
     'DEBUG': DEBUG,
     'NOTSET': NOTSET,
@@ -19,7 +18,7 @@ _nameToLevel = {
 _levelToName = {
     CRITICAL: 'CRITICAL',
     ERROR: 'ERROR',
-    WARNING: 'WARNING',
+    WARN: 'WARN',
     INFO: 'INFO',
     DEBUG: 'DEBUG',
     NOTSET: 'NOTSET',

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -84,7 +84,7 @@ def test_platform_log():
     # send should have been passed a topic and a message
     topic, message = gapps_mock.send.call_args.args
     assert application_id == message['source']
-    assert 'WARNING' == message['logLevel']
+    assert 'WARN' == message['logLevel']
     assert 'baf' == message['logMessage']
 
 


### PR DESCRIPTION
- WARNING is not a valid log level in GOSS-GRIDAPPS-D LogMessage class. 
- Replaced with WARN

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/gridappsd-python/64)
<!-- Reviewable:end -->
