### PR TITLE
Adding automatic pause option to SimulationArgs

### DIFF
--- a/gridappsd-python-lib/gridappsd/simulation.py
+++ b/gridappsd-python-lib/gridappsd/simulation.py
@@ -56,6 +56,7 @@ class SimulationArgs(ConfigBase):
     timestep_frequency: str = "1000"
     timestep_increment: str = "1000"
     run_realtime: bool = True
+    pause_after_measurements: bool = False
     simulation_name: str = "ieee13nodeckt"
     power_flow_solver_method: str = "NR"
     model_creation_config: ModelCreationConfig = __default_model_creation_config__


### PR DESCRIPTION
This change provides a solution for application testing issues when running against simulations running faster than real time.

To test and use in application testing:

The latest develop of the gridappsd platform must be used.

At a minimum create a Simulation class whose SimulationArgs.run_realtime=False and SimulationArgs.pause_after_measurements=True. The simulation should enter the paused state after each time it publishes measurements. When application testing, after receiving a measurements message from the Simulation instance Simulation.resume() will need to be called to move the simulation forward.