### PR TITLE
chore: loosen stomp-py constraint to >=6.0.0

### DIFF
--- a/gridappsd-python-lib/pyproject.toml
+++ b/gridappsd-python-lib/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "PyYAML>=6.0",
     "pytz>=2022.7",
     "dateutils>=0.6.7",
-    "stomp-py==6.0.0",
+    "stomp-py>=6.0.0",
     "requests>=2.28",
     "python-dotenv>=0.9",
     "loguru>=0.7",


### PR DESCRIPTION
Loosens the stomp-py dependency from ==6.0.0 to >=6.0.0 in gridappsd-python-lib/pyproject.toml, making it consistent with pixi.toml (already >=6.0.0).

Justified by the GADP-044 fix (PR #210): _unpack_stomp_args now handles both the stomp-py 6.x two-arg callback shape and the 8.x/9.x Frame shape, so pinning to exactly 6.0.0 is artificially strict and produced a dependency-conflict warning in the platform build (gridappsd-python requires stomp-py==6.0.0 but the platform force-upgrades to 9.0.0 via test-stomp-topics).

Verified under BOTH stomp-py 6.0.0 (floor) and 9.0.0 (latest): callback extracts (header, message) correctly using the real stomp.utils.Frame, full suite green, ruff/format/mypy clean.

Note: gridappsd-field-bus-lib/info/requirements.txt still hard-pins stomp-py==6.0.0 but is a stale pip-freeze export not referenced by any build; left untouched, flagged separately.