### PR TITLE
ci: add CodeQL advanced setup to scan main and develop

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    # Weekly on Monday at 02:00 UTC, matching the previous default-setup cadence.
+    - cron: '0 2 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, python]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: default
+
+      # autobuild is omitted: both 'python' and 'actions' are interpreted or
+      # declarative languages that require no compilation step; CodeQL indexes
+      # them directly without a build.
+
+      - uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Switches gridappsd-python from GitHub's default CodeQL setup to an advanced setup (a committed `.github/workflows/codeql.yml`). The sole motivation is branch coverage: default setup scans only the default branch (main) and pull requests into it. It cannot be extended to also scan develop via the API (GitHub returns 422). The advanced setup workflow adds push and PR triggers for both main and develop while keeping everything else identical to what default setup was running.

## What changes

- Adds `.github/workflows/codeql.yml` (one file, no other repo changes).
- Languages: `actions` and `python`, matching what default setup currently scans (verified via the code-scanning API before authoring).
- Query suite: `default`, matching default setup.
- Schedule: weekly, Monday 02:00 UTC, matching default setup.
- Triggers: push to main, push to develop, PRs into main, PRs into develop.
- Action versions: `actions/checkout@v4` (consistent with existing repo workflows), `github/codeql-action@v4` (current stable major).
- `autobuild` is omitted: Python and actions (YAML) are interpreted/declarative and require no build step. CodeQL indexes them directly.

## Tradeoff to review

**Merging this PR disables default setup.** GitHub enforces mutual exclusivity: once this workflow runs on main, default setup is deactivated automatically. This PR is a full replacement, not an addition. If the workflow under-scans (wrong languages, wrong branches), we will have traded a working scan for a broken one. The workflow was authored to match the default setup configuration exactly, plus the develop extension.

GOSS-GridAPPS-D is intentionally left on default setup and was not touched.

## No secrets required

CodeQL uses the built-in `GITHUB_TOKEN` via `security-events: write`. No additional secrets or configuration needed.