### PR TITLE
fix: bound cim-graph pin below untested 0.5.0 alpha train (GPY-002)

### DIFF
--- a/gridappsd-field-bus-lib/pyproject.toml
+++ b/gridappsd-field-bus-lib/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 keywords = ["gridappsd", "grid", "activemq", "powergrid", "simulation", "library"]
 dependencies = [
     "gridappsd-python>=2025.3.1a1",
-    "cim-graph>=0.4.3a6",
+    "cim-graph>=0.4.3a6,<0.5.0",
     "click>=8.1",
 ]
 


### PR DESCRIPTION
## Summary

Bounds the field-bus package's cim-graph dependency to stay below the
untested 0.5.0 alpha train, matching the same bound applied to
gridappsd-topology-processor (TO-001, PR #45 in that repo).

cim-graph is a pre-1.0 alpha-train dependency: 0.x minors are
conventionally breaking, and 0.5.0a7 is already published upstream but
untested against this codebase. An unbounded lower-bound-only pin
would silently let the resolver drift onto an untested major, the same
failure class TO-001 fixed on the topology-processor side.

Change:

    "cim-graph>=0.4.3a6"  ->  "cim-graph>=0.4.3a6,<0.5.0"

Only the dependency line in gridappsd-field-bus-lib/pyproject.toml
changes. No package version fields were touched (the CalVer triple
in pixi.toml plus the two pyproject.toml version fields is a release
concern, unrelated to this dependency pin).

## Test plan

- [x] Installed field-bus in a clean venv, confirmed cim-graph resolves
      to 0.4.3a12 (not a 0.5.x)
- [x] `import gridappsd_field_bus` succeeds with no ImportError
- [ ] Review team pass per project conventions