### PR TITLE
fix: field bus forwarder CIM profile, argument order, and mrid option (GPY-003)

### DIFF
--- a/gridappsd-field-bus-lib/gridappsd_field_bus/field_interface/field_proxy_forwarder.py
+++ b/gridappsd-field-bus-lib/gridappsd_field_bus/field_interface/field_proxy_forwarder.py
@@ -14,8 +14,8 @@ except Exception:
 from cimgraph.databases import BlazegraphConnection
 from cimgraph.models import BusBranchModel
 
+import importlib
 import os
-import cimgraph.data_profile.cimhub_ufls as cim
 
 REQUEST_FIELD = ".".join((topics.PROCESS_PREFIX, "request.field"))
 
@@ -64,7 +64,16 @@ class FieldProxyForwarder:
     when direct connection is not possible.
     """
 
-    def __init__(self, connection_url: str, username: str, password: str, mrid: str):
+    def __init__(
+        self,
+        connection_url: str,
+        username: str,
+        password: str,
+        mrid: str,
+        cim_profile: str = os.environ.get("CIMG_CIM_PROFILE", "cimhub_2023"),
+    ):
+        self.cim = importlib.import_module("cimgraph.data_profile." + cim_profile)
+
         # Connect to OT
         self.ot_connection = GridAPPSD()
 
@@ -89,7 +98,7 @@ class FieldProxyForwarder:
         # Subscribe to messages on OT bus
         self.ot_connection.subscribe(topics.field_input_topic(), self.on_message_from_ot)
 
-        os.environ["CIMG_CIM_PROFILE"] = "cimhub_ufls"
+        os.environ["CIMG_CIM_PROFILE"] = cim_profile
         os.environ["CIMG_URL"] = "http://localhost:8889/bigdata/namespace/kb/sparql"
         os.environ["CIMG_DATABASE"] = "powergridmodel"
         os.environ["CIMG_NAMESPACE"] = "http://iec.ch/TC57/CIM100#"
@@ -97,12 +106,12 @@ class FieldProxyForwarder:
         os.environ["CIMG_USE_UNITS"] = "False"
 
         self.database = BlazegraphConnection()
-        distribution_area = cim.DistributionArea(mRID=mrid)
+        distribution_area = self.cim.DistributionArea(mRID=mrid)
         self.network = BusBranchModel(connection=self.database, container=distribution_area, distributed=False)
-        self.network.get_all_edges(cim.DistributionArea)
-        self.network.get_all_edges(cim.Substation)
+        self.network.get_all_edges(self.cim.DistributionArea)
+        self.network.get_all_edges(self.cim.Substation)
 
-        for substation in self.network.graph.get(cim.Substation, {}).values():
+        for substation in self.network.graph.get(self.cim.Substation, {}).values():
             mrid = substation.mRID  # type: ignore[attr-defined]
             print(f"Subscribing to Substation: /topic/goss.gridappsd.field.{mrid}")
             self.ot_connection.subscribe("/topic/goss.gridappsd.field." + mrid, self.on_message_from_ot)

--- a/gridappsd-field-bus-lib/gridappsd_field_bus/forwarder.py
+++ b/gridappsd-field-bus-lib/gridappsd_field_bus/forwarder.py
@@ -33,13 +33,21 @@ from gridappsd_field_bus.field_interface.field_proxy_forwarder import FieldProxy
     show_default="from environment variable GRIDAPPSD_ADDRESS",
     help="Connection URL.",
 )
-def start_forwarder(username, password, connection_url):
+@click.option(
+    "--mrid",
+    default=lambda: os.getenv("GRIDAPPSD_FIELD_BUS_MRID"),
+    type=str,
+    metavar="MRID",
+    show_default="from environment variable GRIDAPPSD_FIELD_BUS_MRID",
+    help="mRID of the distribution area/substation to bridge for field bus forwarding.",
+)
+def start_forwarder(username, password, connection_url, mrid):
     """Start the field proxy forwarder with either a YAML configuration or cmd-line arguments."""
 
-    required = [username, password, connection_url]
+    required = [username, password, connection_url, mrid]
     if not all(required):
         click.echo(
-            "Username, password, and connection URL must be provided either through environment variables or command-line arguments."
+            "Username, password, connection URL, and mrid must be provided either through environment variables or command-line arguments."
         )
         click.Abort()
 
@@ -49,9 +57,14 @@ def start_forwarder(username, password, connection_url):
         click.Abort()
 
     # Use command-line arguments
-    click.echo(f"Using command line arguments: {username}, {password}, {connection_url}")
+    click.echo(f"Using command line arguments: {username}, {password}, {connection_url}, {mrid}")
 
-    FieldProxyForwarder(username, password, connection_url, None)
+    FieldProxyForwarder(
+        connection_url=connection_url,
+        username=username,
+        password=password,
+        mrid=mrid,
+    )
 
     time.sleep(0.1)
 

--- a/gridappsd-field-bus-lib/tests/test_field_proxy_forwarder_cim_profile.py
+++ b/gridappsd-field-bus-lib/tests/test_field_proxy_forwarder_cim_profile.py
@@ -1,0 +1,20 @@
+import importlib
+
+import pytest
+
+
+@pytest.mark.parametrize("cim_profile", ["cimhub_2023"])
+def test_field_proxy_forwarder_imports_cleanly_and_profile_has_required_types(cim_profile):
+    """FieldProxyForwarder must import without raising ModuleNotFoundError, and
+    the configured CIM profile module must expose DistributionArea and
+    Substation, since FieldProxyForwarder.__init__ resolves both from it.
+    """
+    # Import the module under test. This must not raise ModuleNotFoundError,
+    # which was the failure mode when the module imported the now-removed
+    # cimhub_ufls profile unconditionally at module scope.
+    from gridappsd_field_bus.field_interface import field_proxy_forwarder  # noqa: F401
+
+    profile_module = importlib.import_module("cimgraph.data_profile." + cim_profile)
+
+    assert hasattr(profile_module, "DistributionArea")
+    assert hasattr(profile_module, "Substation")


### PR DESCRIPTION
## Summary

Three related fixes to the field bus proxy forwarder, all surfaced during the GPY-003 investigation.

- FieldProxyForwarder imported `cimgraph.data_profile.cimhub_ufls` unconditionally at module scope. That profile no longer exists in the pinned cim-graph release, so any import of the module raised ModuleNotFoundError. Replaced it with a configurable `cim_profile` constructor parameter (default `cimhub_2023`), resolved dynamically via `importlib.import_module`, mirroring the pattern already used in `agents.py`. Verified `cimhub_2023` exposes both `DistributionArea` and `Substation`, which is everything the constructor needs.
- The CLI in `forwarder.py` called `FieldProxyForwarder(username, password, connection_url, None)` against a constructor signature of `(connection_url, username, password, mrid)`. Username landed in the connection_url slot, and no mrid was ever passed, so substation discovery could not work even once the import bug above is fixed. The call now passes each value by keyword into the correct slot.
- The CLI had no way to supply an mrid at all. Added a `--mrid` click option (with a `GRIDAPPSD_FIELD_BUS_MRID` environment fallback, matching the existing option style) and threaded it into the corrected constructor call.

Added a unit smoke test that imports the forwarder module and asserts the resolved default CIM profile exposes `DistributionArea` and `Substation`, so a future profile default swap that regresses this cannot merge silently. The test does not instantiate `FieldProxyForwarder` and does not stand up any broker or Blazegraph instance, since the constructor connects to live infrastructure.

## Test plan

- [x] New test `test_field_proxy_forwarder_cim_profile.py` passes
- [x] Full field-bus test suite passes (excluding the Docker-dependent Artemis test, which needs a live container)
- [x] `start-field-bus-forwarder --help` shows the new `--mrid` option
- [x] No version fields touched (pixi.toml, both pyproject.toml files)
- [x] Working tree clean; the compute_req_log.txt side effect from importing gridappsd (tracked separately as GPY-004) was restored, not committed